### PR TITLE
Bump six minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'thriftpy',
         'PyStaticConfiguration >= 0.10.3',
         'simplejson',
-        'six>=1.4.0',
+        'six>=1.7.3',
     ],
     extras_require={
         'zipkin': ['py_zipkin'],


### PR DESCRIPTION
After pip installing yelp_clog, at least in some environments, you get:
```
  File "/usr/local/lib/python2.7/dist-packages/retrying.py", line 47, in wrap
    @six.wraps(f)
AttributeError: 'module' object has no attribute 'wraps'
```

Bumping the six dependency higher (I don't know the exact version, but 1.7.3 works and 1.6.1 doesn't) will fix the problem.